### PR TITLE
Test Environment Config

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  config.active_job.queue_adapter = :test
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
## Summary

Add line `config.active_job.queue_adapter = :test` to config/environments/test.rb so emails are not added to sidekiq's mailers queue when running specs.

## Trello Card
https://trello.com/c/0VZ9H584/42-test-environment-config